### PR TITLE
Remove unnecessary 'Testsuite: autopkgtest' header.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,6 @@ Build-Depends: debhelper (>= 9), dh-python,
  python-all, python-setuptools, django-testscenarios,
  python3-all, python3-setuptools, python3-django-testscenarios
 X-Python-Version: >=2.7
-Testsuite: autopkgtest
 Standards-Version: 4.0.0
 Homepage: http://www.linaro.org/engineering/validation
 Vcs-Browser: https://github.com/Linaro/pkg-django-restricted-resource


### PR DESCRIPTION
Remove unnecessary 'Testsuite: autopkgtest' header.

Fixes lintian: unnecessary-testsuite-autopkgtest-field
See https://lintian.debian.org/tags/unnecessary-testsuite-autopkgtest-field.html for more details.
